### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ numpy
 opencv-python
 torch >= 1.3
 matplotlib
+cython==0.29.16
 pycocotools
 tqdm
 Pillow


### PR DESCRIPTION
Installation of `pycocotools` in `requirements.txt` fails with following error:

```
Collecting pycocotools
  Downloading pycocotools-2.0.0.tar.gz (1.5 MB)
     |████████████████████████████████| 1.5 MB 814 kB/s
    ERROR: Command errored out with exit status 1:
     command: /Users/ajaymaity/opt/anaconda3/envs/recycler-logo-test/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/vf/1cr172q55nl6gm3c_5prp3wc0000gn/T/pip-install-73yscaxe/pycocotools/setup.py'"'"'; __file__='"'"'/private/var/folders/vf/1cr172q55nl6gm3c_5prp3wc0000gn/T/pip-install-73yscaxe/pycocotools/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/vf/1cr172q55nl6gm3c_5prp3wc0000gn/T/pip-install-73yscaxe/pycocotools/pip-egg-info
         cwd: /private/var/folders/vf/1cr172q55nl6gm3c_5prp3wc0000gn/T/pip-install-73yscaxe/pycocotools/
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/vf/1cr172q55nl6gm3c_5prp3wc0000gn/T/pip-install-73yscaxe/pycocotools/setup.py", line 2, in <module>
        from Cython.Build import cythonize
    ModuleNotFoundError: No module named 'Cython'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.

```

Installing `cython` solves the issue.